### PR TITLE
Clear framebuffer after mirror hell effect

### DIFF
--- a/neo/renderer/Framebuffer.h
+++ b/neo/renderer/Framebuffer.h
@@ -49,6 +49,10 @@ public:
 	}
 	void Resize(int width, int height, int samples, pixelFormat_t colorFormat, pixelFormat_t depthFormat);
 
+	int GetID() { // JW : for clearing framebuffer effects
+		return num; 
+	}
+
 	idImage* GetColorAttachment() {
 		return colorAttachment;
 	}

--- a/neo/renderer/tr_backend.cpp
+++ b/neo/renderer/tr_backend.cpp
@@ -925,6 +925,16 @@ static void	RB_CopyRender( const void *data, bool copyFromDefaultFramebuffer ) {
 		fhFramebuffer framebuffer("tmp", cmd->imageWidth, cmd->imageHeight, image, nullptr );
 		fhFramebuffer::BlitColor( src, cmd->x, cmd->y, cmd->imageWidth, cmd->imageHeight, &framebuffer );
 		framebuffer.Purge();
+		if ( image == fhFramebuffer::currentRenderFramebuffer->GetColorAttachment() ) // JW : need to do below to clear the mirror hell effect in Mars City 2 so it doesn't leave artifacts in subsequent uses of reflection, imp fireball heat distortion etc.
+		{
+			fhFramebuffer *currentDrawBuffer = fhFramebuffer::GetCurrentDrawBuffer();
+			fhFramebuffer::currentRenderFramebuffer->Bind();
+			glBindFramebuffer( GL_DRAW_FRAMEBUFFER, fhFramebuffer::currentRenderFramebuffer->GetID() );
+			int  samples = fhFramebuffer::currentRenderFramebuffer->GetSamples();
+			auto target = samples > 1 ? GL_TEXTURE_2D_MULTISAMPLE : GL_TEXTURE_2D;
+			glFramebufferTexture2D( GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, target, fhFramebuffer::currentRenderFramebuffer->GetColorAttachment()->texnum, 0 ); // just reattaching it why
+			currentDrawBuffer->Bind();
+		}
 	}
 }
 


### PR DESCRIPTION
Fix for https://github.com/eXistence/fhDOOM/issues/25

Clears jump scare effect from the bathroom mirror in Mars City 2 so it doesn't show in later reflections, imp fireballs, etc.